### PR TITLE
fix: curl parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ jobs:
 | `version`          | (optional) | `roxctl` release version to use, e.g. "4.4.0". The latest available version is used by default. Ignored when `central-endpoint` is specified.                       |
 | `central-endpoint` | (optional) | RHACS Central endpoint to download `roxctl` from. If left unspecified, `roxctl` is downloaded from mirror.openshift.com instead. Requires `central-token` to be set. |
 | `central-token`    | (optional) | Token to access RHACS Central endpoint.                                                         |
+| `skip-tls-verify`  | (optional) | Skip TLS certificate verification for Central's API endpoint. `false` by default. |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   skip-tls-verify:
-    description: "Skip TLS certificate verification for Central's API Endpoint."
+    description: "Skip TLS certificate verification for Central's API endpoint."
     required: false
     default: "false"
 runs:

--- a/action.yml
+++ b/action.yml
@@ -2,21 +2,25 @@ name: Install roxctl
 description: Download roxctl for use in GitHub Actions
 inputs:
   roxctl-release:
-    description: 'roxctl release version to be installed'
+    description: "roxctl release version to be installed."
     required: false
-    default: 'latest'
+    default: "latest"
   install-dir:
-    description: 'Where to install the roxctl binary'
+    description: "Where to install the roxctl binary."
     required: false
-    default: '$HOME/.roxctl'
+    default: "$HOME/.roxctl"
   central-endpoint:
-    description: 'ACS Central endpoint to download roxctl from. If not specified, roxctl will be downloaded from mirror.openshift.com'
+    description: "ACS Central endpoint to download roxctl from. If not specified, roxctl will be downloaded from mirror.openshift.com."
     required: false
-    default: ''
+    default: ""
   central-token:
-    description: 'Token to access ACS Central endpoint.'
+    description: "Token to access ACS Central endpoint."
     required: false
-    default: ''
+    default: ""
+  skip-tls-verify:
+    description: "Skip TLS certificate verification for Central's API Endpoint."
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -41,7 +45,12 @@ runs:
         else
           ENDPOINT="${{ inputs.central-endpoint}}/api/cli/download/roxctl-${OS}-amd64"
         fi
+        SKIP_TLS_VERIFY=""
+        if [[ '${{ inputs.skip-tls-verify }}' == "true" ]]; then
+            SKIP_TLS_VERIFY="-k "
+        fi
         mkdir -p ${{ inputs.install-dir }}
-        curl -H "Authorization: Bearer ${{ inputs.central-token }}" --fail -sL "${ENDPOINT}${EXT}" --output "${{ inputs.install-dir }}/roxctl${EXT}"
+        curl -H "Authorization: Bearer ${{ inputs.central-token }}" "${SKIP_TLS_VERIFY}"--fail -S -L --retry 5 \
+          "${ENDPOINT}${EXT}" --output "${{ inputs.install-dir }}/roxctl${EXT}"
         chmod +x "${{ inputs.install-dir }}/roxctl${EXT}"
         roxctl version


### PR DESCRIPTION
A couple of improvements I encountered while dog fooding this action.

* Added a retry to curl.
* Changed `-s` to `-S` to still show curl errors for easier debugging.
* Added `skip-tls-verify` parameter. This makes it possible to use the action with Centrals that server self-signed certificates.
* Minor formatting changes.