### PR TITLE
fix: white space in argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
             SKIP_TLS_VERIFY="-k "
         fi
         mkdir -p ${{ inputs.install-dir }}
-        curl -H "Authorization: Bearer ${{ inputs.central-token }}" "${SKIP_TLS_VERIFY}"--fail -S -L --retry 5 \
+        curl -H "Authorization: Bearer ${{ inputs.central-token }}" ${SKIP_TLS_VERIFY}--fail -S -L --retry 5 \
           "${ENDPOINT}${EXT}" --output "${{ inputs.install-dir }}/roxctl${EXT}"
         chmod +x "${{ inputs.install-dir }}/roxctl${EXT}"
         roxctl version


### PR DESCRIPTION
I missed in #5 that bash will treat the whitespace as part of the word when it is in spaces instead of separating the arguments. See https://github.com/stackrox/stackrox/actions/runs/8764483132.

This fix should work, see https://github.com/stackrox/stackrox/actions/runs/8764505384.