### PR TITLE
fix: add HTTPS prefix for central endpoint if not given

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         version: [ latest, 4.3.0 ]
-        central-endpoint: [ '', 'https://staging.demo.stackrox.com']
+        central-endpoint: [ '', 'https://staging.demo.stackrox.com', 'staging.demo.stackrox.com:443']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -48,9 +48,7 @@ runs:
 
         # In case we get a central-endpoint and it didn't start with a scheme (e.g. when using the output
         # from central-login), add a HTTPS prefix.
-        if [[ "${ENDPOINT#https://}" == "${ENDPOINT}" ]]; then
-        ENDPOINT="https://${ENDPOINT}"
-        fi
+        ENDPOINT="https://${ENDPOINT#https://}"
 
         SKIP_TLS_VERIFY=""
         if [[ '${{ inputs.skip-tls-verify }}' == "true" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,13 @@ runs:
         else
           ENDPOINT="${{ inputs.central-endpoint}}/api/cli/download/roxctl-${OS}-amd64"
         fi
+
+        # In case we get a central-endpoint and it didn't start with a scheme (e.g. when using the output
+        # from central-login), add a HTTPS prefix.
+        if [[ "${ENDPOINT#https://}" == "${ENDPOINT}" ]]; then
+        ENDPOINT="https://${ENDPOINT}"
+        fi
+
         SKIP_TLS_VERIFY=""
         if [[ '${{ inputs.skip-tls-verify }}' == "true" ]]; then
             SKIP_TLS_VERIFY="-k "


### PR DESCRIPTION
### Description

Add a `https://` prefix to the `central-endpoint` value _iff_ it isn't already there. Reasoning behind the change is that it's currently a bit awkward when using the central-login action:

```yml
      - name: Central Login
        uses: stackrox/central-login@v1
        with:
          endpoint: ${{ env.ROX_URL }}
      - uses: stackrox/roxctl-installer-action@main
        with:
          install-dir: /usr/local/bin
          roxctl-release: 4.4.0
# You need to explicitly prefix it with `https://` here which is kind of unfortunate. `ROX_ENDPOINT` is set by central-login action and follows the roxctl endpoint flag format which is host:port.
          central-endpoint: https://${{ env.ROX_ENDPOINT }}
          central-token: ${{ env.ROX_API_TOKEN }}
```
