### PR TITLE
chore: add custom user-agent

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,8 @@ runs:
             SKIP_TLS_VERIFY="-k "
         fi
         mkdir -p ${{ inputs.install-dir }}
-        curl -H "Authorization: Bearer ${{ inputs.central-token }}" ${SKIP_TLS_VERIFY}--fail -S -L --retry 5 \
+        curl -H "Authorization: Bearer ${{ inputs.central-token }}" -H "User-Agent: roxctl-installer-action" \
+          ${SKIP_TLS_VERIFY}--fail -S -L --retry 5 \
           "${ENDPOINT}${EXT}" --output "${{ inputs.install-dir }}/roxctl${EXT}"
         chmod +x "${{ inputs.install-dir }}/roxctl${EXT}"
         roxctl version

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
             SKIP_TLS_VERIFY="-k "
         fi
         mkdir -p ${{ inputs.install-dir }}
-        curl -H "Authorization: Bearer ${{ inputs.central-token }}" -H "User-Agent: roxctl-installer-action" \
+        curl -H "Authorization: Bearer ${{ inputs.central-token }}" -H "User-Agent: roxctl-installer-GHA" \
           ${SKIP_TLS_VERIFY}--fail -S -L --retry 5 \
           "${ENDPOINT}${EXT}" --output "${{ inputs.install-dir }}/roxctl${EXT}"
         chmod +x "${{ inputs.install-dir }}/roxctl${EXT}"


### PR DESCRIPTION
### Description

Add a custom user-agent for the action which will be used when reaching out to fetch roxctl either from Central or the public mirror.
This will be used to account for usage from the action.
