### PR TITLE
curl retry all errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
         mkdir -p ${{ inputs.install-dir }}
         curl -H "Authorization: Bearer ${{ inputs.central-token }}" -H "User-Agent: roxctl-installer-GHA" \
           ${RUNNER_DEBUG:+--verbose} \
-          ${SKIP_TLS_VERIFY}--fail -S -L --retry 5 --silent --show-error \
+          ${SKIP_TLS_VERIFY}--fail -S -L --retry 5 --retry-all-errors --silent --show-error \
           "${ENDPOINT}${EXT}" --output "${{ inputs.install-dir }}/roxctl${EXT}"
         chmod +x "${{ inputs.install-dir }}/roxctl${EXT}"
         roxctl version


### PR DESCRIPTION
### Description

Instead of retrying in the bash let's use `--retry-all-errors` from curl that was released 4 years ago (7.71) so every modern system should have it.

See:
https://daniel.haxx.se/blog/2020/06/24/curl-7-71-0-blobs-and-retries/
